### PR TITLE
Remove extra argument to PDO::commit()

### DIFF
--- a/include/datawrappers/dbwrapper_class.php
+++ b/include/datawrappers/dbwrapper_class.php
@@ -1437,7 +1437,7 @@ class DataBase {
     return $this->db->beginTransaction();
   }
   public function commit() {
-    return $this->db->commit($str);
+    return $this->db->commit();
   }
   public function rollBack() {
     return $this->db->rollBack();


### PR DESCRIPTION
This fixes a silent failure updating MySQL via transactions.